### PR TITLE
Add support for Emacs versions 27.1, 27.2, 28.1, 28.2, 29.1-29.4, 30.…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -66,6 +66,14 @@ build() {
 download
 
 build master
+build 30.2
+build 30.1
+build 29.4
+build 29.3
+build 29.2
+build 29.1
+build 28.2
+build 28.1
 build 27.2
 build 27.1
 build 26.3

--- a/index.html
+++ b/index.html
@@ -41,6 +41,76 @@
       </tr>
 
       <tr>
+        <td>30.2</td>
+        <td><a href="./30.2/elisp/index.html">Emacs Lisp Reference Manual</a></td>
+        <td><a href="./30.2/emacs/index.html">Emacs User Manual</a></td>
+        <td><a href="./30.2/misc/index.html">Misc Manuals</a></td>
+      </tr>
+
+      <tr>
+        <td>30.1</td>
+        <td><a href="./30.1/elisp/index.html">Emacs Lisp Reference Manual</a></td>
+        <td><a href="./30.1/emacs/index.html">Emacs User Manual</a></td>
+        <td><a href="./30.1/misc/index.html">Misc Manuals</a></td>
+      </tr>
+
+      <tr>
+        <td>29.4</td>
+        <td><a href="./29.4/elisp/index.html">Emacs Lisp Reference Manual</a></td>
+        <td><a href="./29.4/emacs/index.html">Emacs User Manual</a></td>
+        <td><a href="./29.4/misc/index.html">Misc Manuals</a></td>
+      </tr>
+
+      <tr>
+        <td>29.3</td>
+        <td><a href="./29.3/elisp/index.html">Emacs Lisp Reference Manual</a></td>
+        <td><a href="./29.3/emacs/index.html">Emacs User Manual</a></td>
+        <td><a href="./29.3/misc/index.html">Misc Manuals</a></td>
+      </tr>
+
+      <tr>
+        <td>29.2</td>
+        <td><a href="./29.2/elisp/index.html">Emacs Lisp Reference Manual</a></td>
+        <td><a href="./29.2/emacs/index.html">Emacs User Manual</a></td>
+        <td><a href="./29.2/misc/index.html">Misc Manuals</a></td>
+      </tr>
+
+      <tr>
+        <td>29.1</td>
+        <td><a href="./29.1/elisp/index.html">Emacs Lisp Reference Manual</a></td>
+        <td><a href="./29.1/emacs/index.html">Emacs User Manual</a></td>
+        <td><a href="./29.1/misc/index.html">Misc Manuals</a></td>
+      </tr>
+
+      <tr>
+        <td>28.2</td>
+        <td><a href="./28.2/elisp/index.html">Emacs Lisp Reference Manual</a></td>
+        <td><a href="./28.2/emacs/index.html">Emacs User Manual</a></td>
+        <td><a href="./28.2/misc/index.html">Misc Manuals</a></td>
+      </tr>
+
+      <tr>
+        <td>28.1</td>
+        <td><a href="./28.1/elisp/index.html">Emacs Lisp Reference Manual</a></td>
+        <td><a href="./28.1/emacs/index.html">Emacs User Manual</a></td>
+        <td><a href="./28.1/misc/index.html">Misc Manuals</a></td>
+      </tr>
+
+      <tr>
+        <td>27.2</td>
+        <td><a href="./27.2/elisp/index.html">Emacs Lisp Reference Manual</a></td>
+        <td><a href="./27.2/emacs/index.html">Emacs User Manual</a></td>
+        <td><a href="./27.2/misc/index.html">Misc Manuals</a></td>
+      </tr>
+
+      <tr>
+        <td>27.1</td>
+        <td><a href="./27.1/elisp/index.html">Emacs Lisp Reference Manual</a></td>
+        <td><a href="./27.1/emacs/index.html">Emacs User Manual</a></td>
+        <td><a href="./27.1/misc/index.html">Misc Manuals</a></td>
+      </tr>
+
+      <tr>
         <td>26.3</td>
         <td><a href="./26.3/elisp/index.html">Emacs Lisp Reference Manual</a></td>
         <td><a href="./26.3/emacs/index.html">Emacs User Manual</a></td>


### PR DESCRIPTION
…1, 30.2

Update build.sh to build manuals for all new Emacs versions released since 27.2. Also update index.html to include links to these versions.